### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM        ubuntu:15.10
+FROM        ubuntu:16.04
 MAINTAINER  Frank Lemanschik
  
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Ubuntu15.10のサポートは終了しました。
16.04に変更してdocker buildが通ることを確認しました。