### PR TITLE
Added ability to use varnishncsa for logging

### DIFF
--- a/start
+++ b/start
@@ -5,4 +5,9 @@
 
 # Start varnish and log
 varnishd -f /etc/varnish/default.vcl -s malloc,100M -a 0.0.0.0:${VARNISH_PORT}
-varnishlog
+
+if [ "${VARNISH_LOGGING}" = "ncsa" ]; then
+    varnishncsa "${VARNISH_LOG_OPTIONS}"
+else
+    varnishlog "${VARNISH_LOG_OPTIONS}"
+fi


### PR DESCRIPTION
I needed finer control over the logging, so I add the ability log either via varnishncsa or varnishlog and you can specify options for either command.

example:

`docker run -e "VARNISH_LOGGING=ncsa" -e "VARNISH_LOG_OPTIONS=-F\ '%h %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\" %{Varnish:handling}x'" docker-images`